### PR TITLE
fix: typo in tutorial readme doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install axios
 - axios.get(url)
 - axios.post(url)
 - axios.patch/put(url)
-- axios.delete(ulr)
+- axios.delete(url)
 
 - default get axios(url)
 


### PR DESCRIPTION
Hi! I have fixed the typo in the Axios course tutorial README doc from `axios.delete(ulr)` to `axios.delete(url)`

## Before
![image](https://user-images.githubusercontent.com/69510006/226879025-b907f2b9-a675-42a8-9511-a704f494e202.png)


## After
![image](https://user-images.githubusercontent.com/69510006/226878618-0291182c-4eaa-441b-8f66-d7ba4939cbf4.png)


Thanks & Regards
